### PR TITLE
Update macros.hpp

### DIFF
--- a/include/nanorange/detail/macros.hpp
+++ b/include/nanorange/detail/macros.hpp
@@ -50,7 +50,7 @@ inline namespace ranges                                                        \
 #ifdef NANO_HAVE_INLINE_VARS
 #define NANO_INLINE_VAR(type, name)                                            \
     inline namespace function_objects {                                        \
-    inline constexpr type name{};                                              \
+    static inline constexpr type name{};                                       \
     }
 
 #else


### PR DESCRIPTION
fixing -Wmissing-variable-declarations clang warning with NanoRange.hpp

Even if you use inline namespace:
https://stackoverflow.com/questions/33877510/do-inline-namespace-variables-have-internal-linkage-if-not-why-does-the-code-b